### PR TITLE
Implement bug fix for module reducer

### DIFF
--- a/src/reducers/modules.js
+++ b/src/reducers/modules.js
@@ -12,14 +12,14 @@ export default (state = initialState, action) => {
     case 'EDIT_NODE':
       let path = action.data.path.join('.');
       let value = Object.values(action.data.update).map((v) => v.id)[0]
-      newState = {...state};
+      newState = [...state];
       _.set(newState, path, value);
-      return {...newState}
+      return [...newState]
     case 'ADD_NODE':
       newState[action.data.currentModuleIndex].states = {...newState[action.data.currentModuleIndex].states, ...{'NEW_STATE': {}}};
       return [...newState]
     case 'RENAME_NODE':
-      newState = {...state};
+      newState = [...state];
       let oldModule = newState[action.data.targetModuleIndex].states[action.data.targetNode.name];
       newState[action.data.targetModuleIndex].states[action.data.newName.name] = oldModule;
       delete newState[action.data.targetModuleIndex].states[action.data.targetNode.name];


### PR DESCRIPTION
A bug existed in the module reducer. The state was being destructured into an object rather than an array, causing the module builder to break whenever an edit happened. This PR fixes this bug.