### PR TITLE
Some initial structure templates

### DIFF
--- a/src/templates/Templates.js
+++ b/src/templates/Templates.js
@@ -23,6 +23,11 @@ export const TypeTemplates = {
       quantity: 0,
       unit: "years"
     },
+    Date: {
+      condition_type: 'Date',
+      operator: ">",
+      year: 2000,
+    },
     ActiveCondition: {
       condition_type: 'Active Condition',
       codes: [{
@@ -80,6 +85,23 @@ export const StateTemplates = {
     codes: [{...TypeTemplates.Code}]
   },
 
+  MedicationOrder: {
+    type: "MedicationOrder",
+    codes: [{...TypeTemplates.Code}]
+  },
+
+  Procedure: {
+    type: "Procedure",
+    codes: [{...TypeTemplates.Code}]
+  },
+
+  Observation: {
+    type: "Observation",
+    category: "vital-signs",
+    unit: "",
+    codes: [{...TypeTemplates.Code}]
+  },
+
   Guard: {
     type: "Guard",
     allow: {...TypeTemplates.Condition.Age}
@@ -89,8 +111,78 @@ export const StateTemplates = {
 export const StructureTemplates = {
   CheckYearly: {
     CheckYearly: {...StateTemplates.Delay, exact: {...TypeTemplates.exact, quantity: 1, unit: 'years'},
-      conditional_transition: [{transition: 'CheckYearly'},{transition: 'HasCondition', condition: {...TypeTemplates.Condition.ActiveCondition}}]},
+      conditional_transition: [{transition: 'HasCondition', condition: {...TypeTemplates.Condition.ActiveCondition}},{transition: 'CheckYearly'}]},
     HasCondition: {...StateTemplates.Simple, direct_transition: 'Terminal'}
+  },
+
+  ConditionIncidence: {
+    RiskPerMonth: {...StateTemplates.Delay, exact: {...TypeTemplates.exact, quantity: 1, unit: 'months'},
+      distributed_transition: [{distribution: 0.99, transition: 'RiskPerMonth'},{distribution: 0.01, transition: 'AcquireCondition'}]},
+    AcquireCondition: {...StateTemplates.ConditionOnset, codes:[{system: 'SNOMED-CT', code: '', display: ''}], direct_transition: 'Terminal'}
+  },
+
+  GenderDifference: {
+    GenderDifference: {...StateTemplates.Simple,
+          conditional_transition: [
+            {condition: {...TypeTemplates.Condition.Gender, gender: 'M'}, transition: 'Male'},
+            {condition: {...TypeTemplates.Condition.Gender, gender: 'F'}, transition: 'Female'}]},
+    Male: {...StateTemplates.Simple, direct_transition: 'Common'},
+    Female: {...StateTemplates.Simple, direct_transition: 'Common'},
+    Common: {...StateTemplates.Simple, direct_transition: 'Terminal'}
+  },
+
+  ConditionVariation: {
+    VariantDistribution: {...StateTemplates.Simple,
+      distributed_transition:[{distribution: 0.25, transition: 'Condition1'},{distribution: 0.35, transition: 'Condition2'},{distribution: 0.40, transition: 'Condition3'}]},
+    Condition1: {...StateTemplates.ConditionOnset, codes:[{system: 'SNOMED-CT', code: '', display: ''}], direct_transition: 'Join'},
+    Condition2: {...StateTemplates.ConditionOnset, codes:[{system: 'SNOMED-CT', code: '', display: ''}], direct_transition: 'Join'},
+    Condition3: {...StateTemplates.ConditionOnset, codes:[{system: 'SNOMED-CT', code: '', display: ''}], direct_transition: 'Join'},
+    Join: {...StateTemplates.Simple, direct_transition: 'Terminal'}
+  },
+
+  MedicationVariation: {
+    VariantDistribution: {...StateTemplates.Simple,
+      distributed_transition:[{distribution: 0.25, transition: 'Medication1'},{distribution: 0.35, transition: 'Medication2'},{distribution: 0.40, transition: 'Medication3'}]},
+    Medication1: {...StateTemplates.MedicationOrder, codes:[{system: 'RxNorm', code: '', display: ''}], direct_transition: 'Join'},
+    Medication2: {...StateTemplates.MedicationOrder, codes:[{system: 'RxNorm', code: '', display: ''}], direct_transition: 'Join'},
+    Medication3: {...StateTemplates.MedicationOrder, codes:[{system: 'RxNorm', code: '', display: ''}], direct_transition: 'Join'},
+    Join: {...StateTemplates.Simple, direct_transition: 'Terminal'}
+  },
+
+  ChildrensDose: {
+    DosageDecision: {...StateTemplates.Simple,
+          conditional_transition: [
+            {condition: {...TypeTemplates.Condition.Age, operator: '>=', quantity: 18, unit: 'years'}, transition: 'AdultDose'},
+            {transition: 'ChildrensDose'}]},
+    AdultDose: {...StateTemplates.MedicationOrder, codes:[{system: 'RxNorm', code: '', display: ''}], direct_transition: 'Join'},
+    ChildrensDose: {...StateTemplates.MedicationOrder, codes:[{system: 'RxNorm', code: '', display: ''}], direct_transition: 'Join'},
+    Join: {...StateTemplates.Simple, direct_transition: 'Terminal'}
+  },
+
+  MedicationsByYear: {
+    VariantsByYear: {...StateTemplates.Simple,
+          conditional_transition: [
+            {condition: {...TypeTemplates.Condition.Date, operator: '>=', year: 2007}, transition: 'Medication1'},
+            {condition: {...TypeTemplates.Condition.Date, operator: '>=', year: 1992}, transition: 'Medication2'},
+            {condition: {...TypeTemplates.Condition.Date, operator: '>=', year: 1978}, transition: 'Medication3'},
+            {transition: 'Medication4'}]},
+    Medication1: {...StateTemplates.MedicationOrder, codes:[{system: 'RxNorm', code: '', display: ''}], direct_transition: 'Join'},
+    Medication2: {...StateTemplates.MedicationOrder, codes:[{system: 'RxNorm', code: '', display: ''}], direct_transition: 'Join'},
+    Medication3: {...StateTemplates.MedicationOrder, codes:[{system: 'RxNorm', code: '', display: ''}], direct_transition: 'Join'},
+    Medication4: {...StateTemplates.MedicationOrder, codes:[{system: 'RxNorm', code: '', display: ''}], direct_transition: 'Join'},
+    Join: {...StateTemplates.Simple, direct_transition: 'Terminal'}
+  },
+
+  ProcedureVariation: {
+    BeginEncounter: {...StateTemplates.Encounter, codes:[{system: 'SNOMED-CT', code: '', display: ''}],
+      distributed_transition:[{distribution: 0.25, transition:'Procedure1'},{distribution: 0.35, transition:'Procedure2'},{distribution: 0.40, transition:'Procedure3'}]},
+    Procedure1: {...StateTemplates.Procedure, codes:[{system: 'LOINC', code: '', display: ''}], direct_transition: 'Observation1'},
+    Observation1: {...StateTemplates.Observation, codes:[{system: 'SNOMED-CT', code: '', display: ''}], direct_transition: 'Join'},
+    Procedure2: {...StateTemplates.Procedure, codes:[{system: 'LOINC', code: '', display: ''}], direct_transition: 'Observation2'},
+    Observation2: {...StateTemplates.Observation, codes:[{system: 'SNOMED-CT', code: '', display: ''}], direct_transition: 'Join'},
+    Procedure3: {...StateTemplates.Procedure, codes:[{system: 'LOINC', code: '', display: ''}], direct_transition: 'Observation3'},
+    Observation3: {...StateTemplates.Observation, codes:[{system: 'SNOMED-CT', code: '', display: ''}], direct_transition: 'Join'},
+    Join: {...StateTemplates.Simple, direct_transition: 'Terminal'}
   }
 }
 


### PR DESCRIPTION
Adds some structure templates based on the new template system added in #25.
Note that these can't be added yet in the default UI, we'll need some kind of palette (beyond my web dev abilities in the short term)

Screenshots of the new structures, captured by creating a new module and clicking Add Structure:

#### Condition Incidence
Used to give a certain chance of acquiring a condition each (month, year etc). Ex, you have a 1% chance of getting a cold each month
![condition_incidence](https://user-images.githubusercontent.com/13512036/35156282-60a37c68-fcfe-11e7-8706-842841af6e85.PNG)

#### Gender Difference
Split the population across gender lines, useful for conditions that vary based on gender
![gender_difference](https://user-images.githubusercontent.com/13512036/35156281-6091c3ce-fcfe-11e7-86f9-b992049e1a27.PNG)

#### Condition Variation
Used to assign different conditions that are similar but not the same. Ex, COPD is a blanket term for Emphysema and Chronic Bronchitis; flus and colds may have different variants but very similar risk factors, etc
![condition_variants](https://user-images.githubusercontent.com/13512036/35156280-6077b312-fcfe-11e7-99b7-f2bd914278f1.PNG)

#### Medication Variation
Used when the literature says "drug X, Y, or Z" may be used, but we can't find info on when to use one versus the other. 
![medication_variation](https://user-images.githubusercontent.com/13512036/35156279-605c0860-fcfe-11e7-835a-bba7e692af7b.PNG)

#### Medications by Year
Used to filter medications by the year they were developed or FDA approved. Synthea patients shouldn't be receiving a medication in 1960 if it wasn't introduced until 1980
![medications_by_year](https://user-images.githubusercontent.com/13512036/35156277-60377bd0-fcfe-11e7-8dfe-83952bee4b24.PNG)

#### Children's Medication Dosage
For when medication dosage differs between children & adults
![childrens_med_dosage](https://user-images.githubusercontent.com/13512036/35156278-604db882-fcfe-11e7-988a-f9e909701884.PNG)




![procedure_variants](https://user-images.githubusercontent.com/13512036/35156284-60b70684-fcfe-11e7-9a6e-b32226235ba0.PNG)
