### PR TITLE
Implement units of time drop downs

### DIFF
--- a/src/components/editor/Conditional.js
+++ b/src/components/editor/Conditional.js
@@ -93,13 +93,21 @@ class Age extends Component<Props> {
 
   render() {
     let conditional = ((this.props.conditional: any): AgeConditional);
-    let options = [{id: '==' , text:'==' }, {id: '!=' , text:'!=' }, {id: "<" , text:"<" }, {id: "<=" , text:"<=" }, {id: ">" , text:">" }, {id: ">=", text:">="}];
-
+    let operatorOptions = [{id: '==' , text:'==' }, {id: '!=' , text:'!=' }, {id: "<" , text:"<" }, {id: "<=" , text:"<=" }, {id: ">" , text:">" }, {id: ">=", text:">="}];
+    let unitOptions = [
+      {id: 'years', text: 'years'},
+      {id: 'months', text: 'months'},
+      {id: 'weeks', text: 'weeks'},
+      {id: 'days', text: 'days'},
+      {id: 'hours', text: 'hours'},
+      {id: 'minutes', text: 'minutes'},
+      {id: 'seconds', text: 'seconds'}
+    ];
     return (
       <label> Age:
-      <RIESelect value={{id: conditional.operator, text: conditional.operator}} propName="operator" change={this.props.onChange('operator')} options={options} />
+      <RIESelect value={{id: conditional.operator, text: conditional.operator}} propName="operator" change={this.props.onChange('operator')} options={operatorOptions} />
       <RIENumber value={conditional.quantity} propName='quantity' change={this.props.onChange('quantity')} />
-      <RIEInput value={conditional.unit} propName="unit" change={this.props.onChange('unit')} />
+      <RIESelect value={{id: conditional.unit, text: conditional.unit}} propName="unit" change={this.props.onChange('unit')} options={unitOptions} />
       </label>
     );
   }

--- a/src/components/editor/Conditional.js
+++ b/src/components/editor/Conditional.js
@@ -10,6 +10,16 @@ type Props = {
   onChange: any
 }
 
+const unitOfAgeOptions = [
+  {id: 'years', text: 'years'},
+  {id: 'months', text: 'months'},
+  {id: 'weeks', text: 'weeks'},
+  {id: 'days', text: 'days'},
+  {id: 'hours', text: 'hours'},
+  {id: 'minutes', text: 'minutes'},
+  {id: 'seconds', text: 'seconds'}
+];
+
 class ConditionalEditor extends Component<Props> {
 
   renderConditionalType() {
@@ -93,21 +103,12 @@ class Age extends Component<Props> {
 
   render() {
     let conditional = ((this.props.conditional: any): AgeConditional);
-    let operatorOptions = [{id: '==' , text:'==' }, {id: '!=' , text:'!=' }, {id: "<" , text:"<" }, {id: "<=" , text:"<=" }, {id: ">" , text:">" }, {id: ">=", text:">="}];
-    let unitOptions = [
-      {id: 'years', text: 'years'},
-      {id: 'months', text: 'months'},
-      {id: 'weeks', text: 'weeks'},
-      {id: 'days', text: 'days'},
-      {id: 'hours', text: 'hours'},
-      {id: 'minutes', text: 'minutes'},
-      {id: 'seconds', text: 'seconds'}
-    ];
+    let options = [{id: '==' , text:'==' }, {id: '!=' , text:'!=' }, {id: "<" , text:"<" }, {id: "<=" , text:"<=" }, {id: ">" , text:">" }, {id: ">=", text:">="}];
     return (
       <label> Age:
-      <RIESelect value={{id: conditional.operator, text: conditional.operator}} propName="operator" change={this.props.onChange('operator')} options={operatorOptions} />
+      <RIESelect value={{id: conditional.operator, text: conditional.operator}} propName="operator" change={this.props.onChange('operator')} options={options} />
       <RIENumber value={conditional.quantity} propName='quantity' change={this.props.onChange('quantity')} />
-      <RIESelect value={{id: conditional.unit, text: conditional.unit}} propName="unit" change={this.props.onChange('unit')} options={unitOptions} />
+      <RIESelect value={{id: conditional.unit, text: conditional.unit}} propName="unit" change={this.props.onChange('unit')} options={unitOfAgeOptions} />
       </label>
     );
   }

--- a/src/components/editor/State.js
+++ b/src/components/editor/State.js
@@ -205,6 +205,15 @@ class Delay extends Component<Props> {
 
   renderExact() {
     let state = ((this.props.state: any): DelayState);
+    let options = [
+      {id: 'years', text: 'years'},
+      {id: 'months', text: 'months'},
+      {id: 'weeks', text: 'weeks'},
+      {id: 'days', text: 'days'},
+      {id: 'hours', text: 'hours'},
+      {id: 'minutes', text: 'minutes'},
+      {id: 'seconds', text: 'seconds'}
+    ];
     if (!state.exact) {
       return null;
     }
@@ -212,7 +221,7 @@ class Delay extends Component<Props> {
       <label>
         Exact Quantity: <RIENumber value={state.exact.quantity} propName='quantity' change={this.props.onChange('exact.quantity')} />
         <br />
-        Exact Unit: <RIEInput value={state.exact.unit} propName='unit' change={this.props.onChange('exact.unit')} />
+        Exact Unit: <RIESelect value={{id: state.exact.unit, text: state.exact.unit}} propName="unit" change={this.props.onChange('exact.unit')} options={options} />
         <br />
       </label>
     );
@@ -220,6 +229,15 @@ class Delay extends Component<Props> {
 
   renderRange() {
     let state = ((this.props.state: any): DelayState);
+    let options = [
+      {id: 'years', text: 'years'},
+      {id: 'months', text: 'months'},
+      {id: 'weeks', text: 'weeks'},
+      {id: 'days', text: 'days'},
+      {id: 'hours', text: 'hours'},
+      {id: 'minutes', text: 'minutes'},
+      {id: 'seconds', text: 'seconds'}
+    ];
     if (!state.range) {
       return null;
     }
@@ -229,7 +247,7 @@ class Delay extends Component<Props> {
         <br />
         Range High: <RIENumber value={state.range.high} propName='high' change={this.props.onChange('range.high')} />
         <br />
-        Range Unit: <RIEInput value={state.range.unit} propName='unit' change={this.props.onChange('range.unit')} />
+        Range Unit: <RIESelect value={{id: state.range.unit, text: state.range.unit}} propName="unit" change={this.props.onChange('range.unit')} options={options} />
         <br />
       </label>
     );
@@ -511,6 +529,15 @@ class MedicationOrder extends Component<Props> {
 
   renderDosage() {
     let state = ((this.props.state: any): MedicationOrderState);
+    let options = [
+      {id: 'years', text: 'years'},
+      {id: 'months', text: 'months'},
+      {id: 'weeks', text: 'weeks'},
+      {id: 'days', text: 'days'},
+      {id: 'hours', text: 'hours'},
+      {id: 'minutes', text: 'minutes'},
+      {id: 'seconds', text: 'seconds'}
+    ];
     if (!state.prescription.dosage) {
       return null;
     }
@@ -522,7 +549,7 @@ class MedicationOrder extends Component<Props> {
         <br />
         Dosage Period: <RIENumber value={state.prescription.dosage.period} propName={'period'}  change={this.props.onChange('prescription.dosage.period')} />
         <br />
-        Dosage Unit: <RIEInput value={state.prescription.dosage.unit} propName={'unit'}  change={this.props.onChange('prescription.dosage.unit')} />
+        Dosage Unit: <RIESelect value={{id: state.prescription.dosage.unit, text: state.prescription.dosage.unit}} propName="unit" change={this.props.onChange('prescription.dosage.unit')} options={options} />
         <br />
       </label>
     );
@@ -530,6 +557,15 @@ class MedicationOrder extends Component<Props> {
 
   renderDuration() {
     let state = ((this.props.state: any): MedicationOrderState);
+    let options = [
+      {id: 'years', text: 'years'},
+      {id: 'months', text: 'months'},
+      {id: 'weeks', text: 'weeks'},
+      {id: 'days', text: 'days'},
+      {id: 'hours', text: 'hours'},
+      {id: 'minutes', text: 'minutes'},
+      {id: 'seconds', text: 'seconds'}
+    ];
     if (!state.prescription.duration) {
       return null;
     }
@@ -537,7 +573,7 @@ class MedicationOrder extends Component<Props> {
       <label>
         Duration Quantity: <RIENumber value={state.prescription.duration.quantity} propName={'quantity'}  change={this.props.onChange('prescription.duration.quantity')} />
         <br />
-        Duration Unit: <RIEInput value={state.prescription.duration.unit} propName={'unit'}  change={this.props.onChange('prescription.duration.unit')} />
+        Duration Unit: <RIESelect value={{id: state.prescription.duration.unit, text: state.prescription.duration.unit}} propName="unit" change={this.props.onChange('prescription.duration.unit')} options={options} />
         <br />
       </label>
     );
@@ -628,6 +664,15 @@ class Procedure extends Component<Props> {
 
   renderDuration() {
     let state = ((this.props.state: any): ProcedureState);
+    let options = [
+      {id: 'years', text: 'years'},
+      {id: 'months', text: 'months'},
+      {id: 'weeks', text: 'weeks'},
+      {id: 'days', text: 'days'},
+      {id: 'hours', text: 'hours'},
+      {id: 'minutes', text: 'minutes'},
+      {id: 'seconds', text: 'seconds'}
+    ];
     if (!state.duration) {
       return null;
     }
@@ -637,7 +682,7 @@ class Procedure extends Component<Props> {
         <br />
         Duration High: <RIENumber value={state.duration.high} propName={'high'}  change={this.props.onChange('duration.high')} />
         <br />
-        Duration Unit: <RIEInput value={state.duration.unit} propName={'unit'}  change={this.props.onChange('duration.unit')} />
+        Duration Unit: <RIESelect value={{id: state.duration.unit, text: state.duration.unit}} propName="unit" change={this.props.onChange('duration.unit')} options={options} />
         <br />
       </label>
     );
@@ -729,6 +774,15 @@ class Death extends Component<Props> {
 
   renderExact() {
     let state = ((this.props.state: any): DeathState);
+    let options = [
+      {id: 'years', text: 'years'},
+      {id: 'months', text: 'months'},
+      {id: 'weeks', text: 'weeks'},
+      {id: 'days', text: 'days'},
+      {id: 'hours', text: 'hours'},
+      {id: 'minutes', text: 'minutes'},
+      {id: 'seconds', text: 'seconds'}
+    ];
     if (!state.exact) {
       return null;
     }
@@ -736,7 +790,7 @@ class Death extends Component<Props> {
       <label>
         Exact Quantity: <RIENumber value={state.exact.quantity} propName='quantity' change={this.props.onChange('exact.quantity')} />
         <br />
-        Exact Unit: <RIEInput value={state.exact.unit} propName='unit' change={this.props.onChange('exact.unit')} />
+        Exact Unit: <RIESelect value={{id: state.exact.unit, text: state.exact.unit}} propName="unit" change={this.props.onChange('exact.unit')} options={options} />
         <br />
       </label>
     );
@@ -744,6 +798,15 @@ class Death extends Component<Props> {
 
   renderRange() {
     let state = ((this.props.state: any): DeathState);
+    let options = [
+      {id: 'years', text: 'years'},
+      {id: 'months', text: 'months'},
+      {id: 'weeks', text: 'weeks'},
+      {id: 'days', text: 'days'},
+      {id: 'hours', text: 'hours'},
+      {id: 'minutes', text: 'minutes'},
+      {id: 'seconds', text: 'seconds'}
+    ];
     if (!state.range) {
       return null;
     }
@@ -753,7 +816,7 @@ class Death extends Component<Props> {
         <br />
         Range High: <RIENumber value={state.range.high} propName='high' change={this.props.onChange('range.high')} />
         <br />
-        Range Unit: <RIEInput value={state.range.unit} propName='unit' change={this.props.onChange('range.unit')} />
+        Range Unit: <RIESelect value={{id: state.range.unit, text: state.range.unit}} propName="unit" change={this.props.onChange('range.unit')} options={options} />
         <br />
       </label>
     );

--- a/src/components/editor/State.js
+++ b/src/components/editor/State.js
@@ -21,6 +21,16 @@ type Props = {
   changeType: any
 }
 
+const unitOfTimeOptions = [
+  {id: 'years', text: 'years'},
+  {id: 'months', text: 'months'},
+  {id: 'weeks', text: 'weeks'},
+  {id: 'days', text: 'days'},
+  {id: 'hours', text: 'hours'},
+  {id: 'minutes', text: 'minutes'},
+  {id: 'seconds', text: 'seconds'}
+];
+
 class StateEditor extends Component<Props> {
 
   renderStateType() {
@@ -205,15 +215,6 @@ class Delay extends Component<Props> {
 
   renderExact() {
     let state = ((this.props.state: any): DelayState);
-    let options = [
-      {id: 'years', text: 'years'},
-      {id: 'months', text: 'months'},
-      {id: 'weeks', text: 'weeks'},
-      {id: 'days', text: 'days'},
-      {id: 'hours', text: 'hours'},
-      {id: 'minutes', text: 'minutes'},
-      {id: 'seconds', text: 'seconds'}
-    ];
     if (!state.exact) {
       return null;
     }
@@ -221,7 +222,7 @@ class Delay extends Component<Props> {
       <label>
         Exact Quantity: <RIENumber value={state.exact.quantity} propName='quantity' change={this.props.onChange('exact.quantity')} />
         <br />
-        Exact Unit: <RIESelect value={{id: state.exact.unit, text: state.exact.unit}} propName="unit" change={this.props.onChange('exact.unit')} options={options} />
+        Exact Unit: <RIESelect value={{id: state.exact.unit, text: state.exact.unit}} propName="unit" change={this.props.onChange('exact.unit')} options={unitOfTimeOptions} />
         <br />
       </label>
     );
@@ -229,15 +230,6 @@ class Delay extends Component<Props> {
 
   renderRange() {
     let state = ((this.props.state: any): DelayState);
-    let options = [
-      {id: 'years', text: 'years'},
-      {id: 'months', text: 'months'},
-      {id: 'weeks', text: 'weeks'},
-      {id: 'days', text: 'days'},
-      {id: 'hours', text: 'hours'},
-      {id: 'minutes', text: 'minutes'},
-      {id: 'seconds', text: 'seconds'}
-    ];
     if (!state.range) {
       return null;
     }
@@ -247,7 +239,7 @@ class Delay extends Component<Props> {
         <br />
         Range High: <RIENumber value={state.range.high} propName='high' change={this.props.onChange('range.high')} />
         <br />
-        Range Unit: <RIESelect value={{id: state.range.unit, text: state.range.unit}} propName="unit" change={this.props.onChange('range.unit')} options={options} />
+        Range Unit: <RIESelect value={{id: state.range.unit, text: state.range.unit}} propName="unit" change={this.props.onChange('range.unit')} options={unitOfTimeOptions} />
         <br />
       </label>
     );
@@ -529,15 +521,6 @@ class MedicationOrder extends Component<Props> {
 
   renderDosage() {
     let state = ((this.props.state: any): MedicationOrderState);
-    let options = [
-      {id: 'years', text: 'years'},
-      {id: 'months', text: 'months'},
-      {id: 'weeks', text: 'weeks'},
-      {id: 'days', text: 'days'},
-      {id: 'hours', text: 'hours'},
-      {id: 'minutes', text: 'minutes'},
-      {id: 'seconds', text: 'seconds'}
-    ];
     if (!state.prescription.dosage) {
       return null;
     }
@@ -549,7 +532,7 @@ class MedicationOrder extends Component<Props> {
         <br />
         Dosage Period: <RIENumber value={state.prescription.dosage.period} propName={'period'}  change={this.props.onChange('prescription.dosage.period')} />
         <br />
-        Dosage Unit: <RIESelect value={{id: state.prescription.dosage.unit, text: state.prescription.dosage.unit}} propName="unit" change={this.props.onChange('prescription.dosage.unit')} options={options} />
+        Dosage Unit: <RIESelect value={{id: state.prescription.dosage.unit, text: state.prescription.dosage.unit}} propName="unit" change={this.props.onChange('prescription.dosage.unit')} options={unitOfTimeOptions} />
         <br />
       </label>
     );
@@ -557,15 +540,6 @@ class MedicationOrder extends Component<Props> {
 
   renderDuration() {
     let state = ((this.props.state: any): MedicationOrderState);
-    let options = [
-      {id: 'years', text: 'years'},
-      {id: 'months', text: 'months'},
-      {id: 'weeks', text: 'weeks'},
-      {id: 'days', text: 'days'},
-      {id: 'hours', text: 'hours'},
-      {id: 'minutes', text: 'minutes'},
-      {id: 'seconds', text: 'seconds'}
-    ];
     if (!state.prescription.duration) {
       return null;
     }
@@ -573,7 +547,7 @@ class MedicationOrder extends Component<Props> {
       <label>
         Duration Quantity: <RIENumber value={state.prescription.duration.quantity} propName={'quantity'}  change={this.props.onChange('prescription.duration.quantity')} />
         <br />
-        Duration Unit: <RIESelect value={{id: state.prescription.duration.unit, text: state.prescription.duration.unit}} propName="unit" change={this.props.onChange('prescription.duration.unit')} options={options} />
+        Duration Unit: <RIESelect value={{id: state.prescription.duration.unit, text: state.prescription.duration.unit}} propName="unit" change={this.props.onChange('prescription.duration.unit')} options={unitOfTimeOptions} />
         <br />
       </label>
     );
@@ -664,15 +638,6 @@ class Procedure extends Component<Props> {
 
   renderDuration() {
     let state = ((this.props.state: any): ProcedureState);
-    let options = [
-      {id: 'years', text: 'years'},
-      {id: 'months', text: 'months'},
-      {id: 'weeks', text: 'weeks'},
-      {id: 'days', text: 'days'},
-      {id: 'hours', text: 'hours'},
-      {id: 'minutes', text: 'minutes'},
-      {id: 'seconds', text: 'seconds'}
-    ];
     if (!state.duration) {
       return null;
     }
@@ -682,7 +647,7 @@ class Procedure extends Component<Props> {
         <br />
         Duration High: <RIENumber value={state.duration.high} propName={'high'}  change={this.props.onChange('duration.high')} />
         <br />
-        Duration Unit: <RIESelect value={{id: state.duration.unit, text: state.duration.unit}} propName="unit" change={this.props.onChange('duration.unit')} options={options} />
+        Duration Unit: <RIESelect value={{id: state.duration.unit, text: state.duration.unit}} propName="unit" change={this.props.onChange('duration.unit')} options={unitOfTimeOptions} />
         <br />
       </label>
     );
@@ -774,15 +739,6 @@ class Death extends Component<Props> {
 
   renderExact() {
     let state = ((this.props.state: any): DeathState);
-    let options = [
-      {id: 'years', text: 'years'},
-      {id: 'months', text: 'months'},
-      {id: 'weeks', text: 'weeks'},
-      {id: 'days', text: 'days'},
-      {id: 'hours', text: 'hours'},
-      {id: 'minutes', text: 'minutes'},
-      {id: 'seconds', text: 'seconds'}
-    ];
     if (!state.exact) {
       return null;
     }
@@ -790,7 +746,7 @@ class Death extends Component<Props> {
       <label>
         Exact Quantity: <RIENumber value={state.exact.quantity} propName='quantity' change={this.props.onChange('exact.quantity')} />
         <br />
-        Exact Unit: <RIESelect value={{id: state.exact.unit, text: state.exact.unit}} propName="unit" change={this.props.onChange('exact.unit')} options={options} />
+        Exact Unit: <RIESelect value={{id: state.exact.unit, text: state.exact.unit}} propName="unit" change={this.props.onChange('exact.unit')} options={unitOfTimeOptions} />
         <br />
       </label>
     );
@@ -798,15 +754,6 @@ class Death extends Component<Props> {
 
   renderRange() {
     let state = ((this.props.state: any): DeathState);
-    let options = [
-      {id: 'years', text: 'years'},
-      {id: 'months', text: 'months'},
-      {id: 'weeks', text: 'weeks'},
-      {id: 'days', text: 'days'},
-      {id: 'hours', text: 'hours'},
-      {id: 'minutes', text: 'minutes'},
-      {id: 'seconds', text: 'seconds'}
-    ];
     if (!state.range) {
       return null;
     }
@@ -816,7 +763,7 @@ class Death extends Component<Props> {
         <br />
         Range High: <RIENumber value={state.range.high} propName='high' change={this.props.onChange('range.high')} />
         <br />
-        Range Unit: <RIESelect value={{id: state.range.unit, text: state.range.unit}} propName="unit" change={this.props.onChange('range.unit')} options={options} />
+        Range Unit: <RIESelect value={{id: state.range.unit, text: state.range.unit}} propName="unit" change={this.props.onChange('range.unit')} options={unitOfTimeOptions} />
         <br />
       </label>
     );

--- a/src/types/Conditional.js
+++ b/src/types/Conditional.js
@@ -11,7 +11,7 @@ export type AgeConditional = {
   condition_type: 'Age',
   operator: '==' | '!=' | "<" | "<=" | ">" | ">=",
   quantity: number,
-  unit: string
+  unit: 'years' | 'months' | 'weeks' | 'days' | 'hours' | 'minutes' | 'seconds'
 }
 
 export type DateConditional = {

--- a/src/types/Conditional.js
+++ b/src/types/Conditional.js
@@ -1,6 +1,7 @@
 // @flow
 
 import type { Code } from './Code';
+import type { UnitOfAge } from './Units';
 
 export type GenderConditional = {
   condition_type: 'Gender',
@@ -11,7 +12,7 @@ export type AgeConditional = {
   condition_type: 'Age',
   operator: '==' | '!=' | "<" | "<=" | ">" | ">=",
   quantity: number,
-  unit: 'years' | 'months' | 'weeks' | 'days' | 'hours' | 'minutes' | 'seconds'
+  unit: UnitOfAge
 }
 
 export type DateConditional = {

--- a/src/types/State.js
+++ b/src/types/State.js
@@ -2,6 +2,7 @@
 import type { Transition } from './Transition';
 import type { Conditional } from './Conditional';
 import type { Code } from './Code';
+import type { UnitOfTime } from './Units';
 
 export type InitialState = {
   name: string,
@@ -33,12 +34,12 @@ export type DelayState = {
   type: 'Delay',
   exact?: {
     quantity: number,
-    unit: 'years' | 'months' | 'weeks' | 'days' | 'hours' | 'minutes' | 'seconds'
+    unit: UnitOfTime
   },
   range?: {
     low: number,
     high: number,
-    unit: 'years' | 'months' | 'weeks' | 'days' | 'hours' | 'minutes' | 'seconds'
+    unit: UnitOfTime
   },
   transition?: Transition
 }
@@ -132,11 +133,11 @@ export type MedicationOrderState = {
       amount: number,
       frequency: number,
       period: number,
-      unit: 'years' | 'months' | 'weeks' | 'days' | 'hours' | 'minutes' | 'seconds'
+      unit: UnitOfTime
     },
     duration: {
       quantity: number,
-      unit: 'years' | 'months' | 'weeks' | 'days' | 'hours' | 'minutes' | 'seconds'
+      unit: UnitOfTime
     },
     instructions?: Code[]
   },
@@ -188,7 +189,7 @@ export type ProcedureState = {
   duration: {
     low: number,
     high: number,
-    unit: 'years' | 'months' | 'weeks' | 'days' | 'hours' | 'minutes' | 'seconds'
+    unit: UnitOfTime
   },
   transition?: Transition
 }
@@ -263,12 +264,12 @@ export type DeathState = {
   type: 'Death',
   exact?: {
     quantity: number,
-    unit: 'years' | 'months' | 'weeks' | 'days' | 'hours' | 'minutes' | 'seconds'
+    unit: UnitOfTime
   },
   range?: {
     low: number,
     high: number,
-    unit: 'years' | 'months' | 'weeks' | 'days' | 'hours' | 'minutes' | 'seconds'
+    unit: UnitOfTime
   },
   codes?: Code[],
   condition_onset?: string,

--- a/src/types/State.js
+++ b/src/types/State.js
@@ -33,12 +33,12 @@ export type DelayState = {
   type: 'Delay',
   exact?: {
     quantity: number,
-    unit: string
+    unit: 'years' | 'months' | 'weeks' | 'days' | 'hours' | 'minutes' | 'seconds'
   },
   range?: {
     low: number,
     high: number,
-    unit: string
+    unit: 'years' | 'months' | 'weeks' | 'days' | 'hours' | 'minutes' | 'seconds'
   },
   transition?: Transition
 }
@@ -132,11 +132,11 @@ export type MedicationOrderState = {
       amount: number,
       frequency: number,
       period: number,
-      unit: string
+      unit: 'years' | 'months' | 'weeks' | 'days' | 'hours' | 'minutes' | 'seconds'
     },
     duration: {
       quantity: number,
-      unit: string
+      unit: 'years' | 'months' | 'weeks' | 'days' | 'hours' | 'minutes' | 'seconds'
     },
     instructions?: Code[]
   },
@@ -188,7 +188,7 @@ export type ProcedureState = {
   duration: {
     low: number,
     high: number,
-    unit: string
+    unit: 'years' | 'months' | 'weeks' | 'days' | 'hours' | 'minutes' | 'seconds'
   },
   transition?: Transition
 }
@@ -263,12 +263,12 @@ export type DeathState = {
   type: 'Death',
   exact?: {
     quantity: number,
-    unit: string
+    unit: 'years' | 'months' | 'weeks' | 'days' | 'hours' | 'minutes' | 'seconds'
   },
   range?: {
     low: number,
     high: number,
-    unit: string
+    unit: 'years' | 'months' | 'weeks' | 'days' | 'hours' | 'minutes' | 'seconds'
   },
   codes?: Code[],
   condition_onset?: string,

--- a/src/types/Units.js
+++ b/src/types/Units.js
@@ -1,0 +1,5 @@
+// @flow
+
+export type UnitOfTime = 'years' | 'months' | 'weeks' | 'days' | 'hours' | 'minutes' | 'seconds';
+
+export type UnitOfAge = 'years' | 'months' | 'weeks' | 'days' | 'hours' | 'minutes' | 'seconds';


### PR DESCRIPTION
Previously, any editor that had a unit of time or unit of age required direct value entry through typing. This implements a selection editor instead, to limit these fields to valid values.