### PR TITLE
Fix boolean attributes in editor

### DIFF
--- a/src/components/editor/State.js
+++ b/src/components/editor/State.js
@@ -244,9 +244,6 @@ class SetAttribute extends Component<Props> {
 
   renderValue() {
     let state = ((this.props.state: any): SetAttributeState);
-    if (!state.value) {
-      return null;
-    }
     return (
       <label>
         Exact Quantity: <RIEInput value={state.value} propName='value' change={this.props.onChange('value')} />
@@ -320,9 +317,6 @@ class Encounter extends Component<Props> {
 
   renderWellness() {
     let state = ((this.props.state: any): EncounterState);
-    if (!state.wellness) {
-      return null;
-    }
     return (
       <label>
         Wellness: <RIEToggle value={state.wellness} propName={'wellness'}  change={this.props.onChange('wellness')} />
@@ -622,9 +616,6 @@ class MedicationOrder extends Component<Props> {
 
   renderAsNeeded() {
     let state = ((this.props.state: any): MedicationOrderState);
-    if (!state.prescription.as_needed) {
-      return null;
-    }
     return (
       <label>
         Prescription As Needed: <RIEToggle value={state.prescription.as_needed} propName={'as_needed'}  change={this.props.onChange('prescription.as_needed')} />

--- a/src/components/editor/State.js
+++ b/src/components/editor/State.js
@@ -246,7 +246,7 @@ class SetAttribute extends Component<Props> {
     let state = ((this.props.state: any): SetAttributeState);
     return (
       <label>
-        Exact Quantity: <RIEInput value={state.value} propName='value' change={this.props.onChange('value')} />
+        Exact Quantity: <RIEInput value={state.value || false} propName='value' change={this.props.onChange('value')} />
         <br />
       </label>
     );
@@ -319,7 +319,7 @@ class Encounter extends Component<Props> {
     let state = ((this.props.state: any): EncounterState);
     return (
       <label>
-        Wellness: <RIEToggle value={state.wellness} propName={'wellness'}  change={this.props.onChange('wellness')} />
+        Wellness: <RIEToggle value={state.wellness || false} propName={'wellness'}  change={this.props.onChange('wellness')} />
         <br />
       </label>
     );
@@ -618,7 +618,7 @@ class MedicationOrder extends Component<Props> {
     let state = ((this.props.state: any): MedicationOrderState);
     return (
       <label>
-        Prescription As Needed: <RIEToggle value={state.prescription.as_needed} propName={'as_needed'}  change={this.props.onChange('prescription.as_needed')} />
+        Prescription As Needed: <RIEToggle value={state.prescription.as_needed || false} propName={'as_needed'}  change={this.props.onChange('prescription.as_needed')} />
         <br />
       </label>
     );


### PR DESCRIPTION
Fixes error with toggles on boolean attributes disappearing when false. This is because null checking for these values is not necessary or desired, since the values are allowed to be null and should still be editable as such.

Example states with applicable attributes to check are Wellness_Encounter in Examplitis and Prescribe_Epipen in Allergies and Treatment.

This should resolve #48 which relates to this bug, specifically in regards to the wellness attribute.