### PR TITLE
Implement additional state templates and polish code editors

### DIFF
--- a/src/components/editor/Code.js
+++ b/src/components/editor/Code.js
@@ -16,14 +16,14 @@ export class Code extends Component<Props> {
 
   render() {
     let code = this.props.code;
-    let codeTypeOptions = ["SNOMED-CT", "RxNorm", "LOINC"].map((c) => {return {id: c, text: c}});
+    let system = this.props.system;
     return (
       <div>
-        System: <RIESelect value={{id: code.system, text: code.system}} propName="system" change={this.props.onChange('system')} options={codeTypeOptions} />
-        <br />
-        Display: <RIEInput value={code.display} propName="display" change={this.props.onChange('display')} />
+        System: {system}
         <br />
         Code: <RIEInput value={code.code} propName="code" change={this.props.onChange('code')} />
+        <br />
+        Display: <RIEInput value={code.display} propName="display" change={this.props.onChange('display')} />
       </div>
     );
   }
@@ -40,17 +40,24 @@ export class Codes extends Component<CodesProps> {
     if(!this.props.codes){
       return null;
     }
+    let system = this.props.system;
+    let templates = {
+      "SNOMED-CT": TypeTemplates.Code.Snomed,
+      "LOINC": TypeTemplates.Code.Loinc,
+      "RxNorm": TypeTemplates.Code.RxNorm,
+      "NUBC": TypeTemplates.Code.Nubc
+    };
     return (
       <div>
         {this.props.codes.map((code, i) => {
           return (
             <div key={i}>
               <a onClick={() => this.props.onChange(`[${i}]`)({val: {id: null}})}>x</a>
-              <Code onChange={this.props.onChange(i)} code={code} />
+              <Code onChange={this.props.onChange(i)} code={code} system={system} />
             </div>
           )
         })}
-        <a onClick={() => this.props.onChange(`[${this.props.codes.length}]`)({val: {id: _.cloneDeep(TypeTemplates.Code)}})}>+</a>
+        <a onClick={() => this.props.onChange(`[${this.props.codes.length}]`)({val: {id: _.cloneDeep(templates[system])}})}>+</a>
 
       </div>
     );

--- a/src/components/editor/State.js
+++ b/src/components/editor/State.js
@@ -313,7 +313,7 @@ class Encounter extends Component<Props> {
         Encounter Class: <RIESelect value={{id: state.encounter_class, text: state.encounter_class}} propName="encounter_class" change={this.props.onChange('encounter_class')} options={options} />
         <br />
         {this.renderReason()}
-        <Codes codes={state.codes} onChange={this.props.onChange('codes')} />
+        <Codes codes={state.codes} system={"SNOMED-CT"} onChange={this.props.onChange('codes')} />
       </div>
     );
   }
@@ -366,7 +366,7 @@ class EncounterEnd extends Component<Props> {
     }
     return (
       <label>
-        <Code code={state.discharge_disposition} onChange={this.props.onChange('discharge_disposition')} />
+        <Code code={state.discharge_disposition} system={"NUBC"} onChange={this.props.onChange('discharge_disposition')} />
         <br />
       </label>
     );
@@ -385,7 +385,7 @@ class ConditionOnset extends Component<Props> {
         Target Encounter: <RIEInput value={state.target_encounter || ''} propName={'target_encounter'} change={this.props.onChange('target_encounter')} />
         <br />
         {this.renderAssignToAttribute()}
-        <Codes codes={state.codes} onChange={this.props.onChange('codes')} />
+        <Codes codes={state.codes} system={"SNOMED-CT"} onChange={this.props.onChange('codes')} />
       </div>
     );
   }
@@ -453,7 +453,7 @@ class ConditionEnd extends Component<Props> {
     }
     return (
       <label>
-        <Codes codes={state.codes} onChange={this.props.onChange('codes')} />
+        <Codes codes={state.codes} system={"SNOMED-CT"} onChange={this.props.onChange('codes')} />
         <br />
       </label>
     );
@@ -472,7 +472,7 @@ class AllergyOnset extends Component<Props> {
         Target Encounter: <RIEInput value={state.target_encounter} propName={'target_encounter'} change={this.props.onChange('target_encounter')} />
         <br />
         {this.renderAssignToAttribute()}
-        <Codes codes={state.codes} onChange={this.props.onChange('codes')} />
+        <Codes codes={state.codes} system={"SNOMED-CT"} onChange={this.props.onChange('codes')} />
       </div>
     );
   }
@@ -540,7 +540,7 @@ class AllergyEnd extends Component<Props> {
     }
     return (
       <label>
-        <Codes codes={state.codes} onChange={this.props.onChange('codes')} />
+        <Codes codes={state.codes} system={"SNOMED-CT"} onChange={this.props.onChange('codes')} />
         <br />
       </label>
     );
@@ -558,7 +558,7 @@ class MedicationOrder extends Component<Props> {
         <br />
         {this.renderAssignToAttribute()}
         {this.renderReason()}
-        <Codes codes={state.codes} onChange={this.props.onChange('codes')} />
+        <Codes codes={state.codes} system={"RxNorm"} onChange={this.props.onChange('codes')} />
         <br />
         {this.renderPrescription()}
       </div>
@@ -674,7 +674,7 @@ class MedicationOrder extends Component<Props> {
     }
     return (
       <label>
-        <Codes codes={state.prescription.instructions} onChange={this.props.onChange('prescription.instructions')} />
+        <Codes codes={state.prescription.instructions} system={"SNOMED-CT"} onChange={this.props.onChange('prescription.instructions')} />
         <br />
       </label>
     );
@@ -730,7 +730,7 @@ class MedicationEnd extends Component<Props> {
     }
     return (
       <label>
-        <Codes codes={state.codes} onChange={this.props.onChange('codes')} />
+        <Codes codes={state.codes} system={"RxNorm"} onChange={this.props.onChange('codes')} />
         <br />
       </label>
     );
@@ -748,7 +748,7 @@ class CarePlanStart extends Component<Props> {
         <br/>
         {this.renderAssignToAttribute()}
         {this.renderReason()}
-        <Codes codes={state.codes} onChange={this.props.onChange('codes')} />
+        <Codes codes={state.codes} system={"SNOMED-CT"} onChange={this.props.onChange('codes')} />
         <br/>
         {this.renderActivities()}
         {this.renderGoals()}
@@ -789,7 +789,7 @@ class CarePlanStart extends Component<Props> {
     }
     return (
       <label>
-        <Codes codes={state.activities} onChange={this.props.onChange('activities')} />
+        <Codes codes={state.activities} system={"SNOMED-CT"} onChange={this.props.onChange('activities')} />
         <br />
       </label>
     );
@@ -826,7 +826,7 @@ class CarePlanStart extends Component<Props> {
     }
     return (
       <label>
-        <Codes codes={state.goals.observation.codes} onChange={this.props.onChange('goals.observation.codes')} />
+        <Codes codes={state.goals.observation.codes} system={"SNOMED-CT"} onChange={this.props.onChange('goals.observation.codes')} />
         <br />
         Goal Observation Operator: <RIESelect value={{id: state.goals.observation.operator, text: state.goals.observation.operator}} propName="operator" change={this.props.onChange('goals.observation.operator')} options={options} />
         <br/>
@@ -912,7 +912,7 @@ class CarePlanEnd extends Component<Props> {
     }
     return (
       <label>
-        <Codes codes={state.codes} onChange={this.props.onChange('codes')} />
+        <Codes codes={state.codes} system={"SNOMED-CT"} onChange={this.props.onChange('codes')} />
         <br />
       </label>
     );
@@ -929,7 +929,7 @@ class Procedure extends Component<Props> {
         Name: <RIEInput propName={'name'} value={state.name} change={this.props.renameNode} />
         <br />
         {this.renderReason()}
-        <Codes codes={state.codes} onChange={this.props.onChange('codes')} />
+        <Codes codes={state.codes} system={"SNOMED-CT"} onChange={this.props.onChange('codes')} />
         <br />
         {this.renderDuration()}
       </div>
@@ -1038,7 +1038,7 @@ class Observation extends Component<Props> {
         <br/>
         Unit: <RIEInput value={state.unit} propName={'unit'} change={this.props.onChange('unit')} />
         <br/>
-        <Codes codes={state.codes} onChange={this.props.onChange('codes')} />
+        <Codes codes={state.codes} system={"LOINC"} onChange={this.props.onChange('codes')} />
         <br/>
         {this.renderExact()}
         {this.renderRange()}
@@ -1126,7 +1126,7 @@ class MultiObservation extends Component<Props> {
         <br/>
         Number of Observations: <RIENumber value={state.number_of_observations} propName='number_of_observations' change={this.props.onChange('number_of_observations')} />
         <br/>
-        <Codes codes={state.codes} onChange={this.props.onChange('codes')} />
+        <Codes codes={state.codes} system={"LOINC"} onChange={this.props.onChange('codes')} />
         <br/>
       </div>
     );
@@ -1144,7 +1144,7 @@ class DiagnosticReport extends Component<Props> {
         <br/>
         Number of Observations: <RIENumber value={state.number_of_observations} propName='number_of_observations' change={this.props.onChange('number_of_observations')} />
         <br/>
-        <Codes codes={state.codes} onChange={this.props.onChange('codes')} />
+        <Codes codes={state.codes} system={"LOINC"} onChange={this.props.onChange('codes')} />
       </div>
     );
   }
@@ -1267,7 +1267,7 @@ class Death extends Component<Props> {
     }
     return (
       <label>
-        <Codes codes={state.codes} onChange={this.props.onChange('codes')} />
+        <Codes codes={state.codes} system={"SNOMED-CT"} onChange={this.props.onChange('codes')} />
         <br />
       </label>
     );

--- a/src/templates/Templates.js
+++ b/src/templates/Templates.js
@@ -1,15 +1,35 @@
 export const TypeTemplates = {
   Range: {
     Exact: {
+      quantity: 0
+    },
+    ExactWithUnit: {
       quantity: 0,
       unit: "days"
     }
   },
 
   Code: {
-    system: "SNOMED-CT",
-    code: "1234",
-    display: "SNOMED Code"
+    Snomed: {
+      system: "SNOMED-CT",
+      code: "1234",
+      display: "SNOMED Code"
+    },
+    Loinc: {
+      system: "LOINC",
+      code: "1234",
+      display: "LOINC Code"
+    },
+    RxNorm: {
+      system: "RxNorm",
+      code: "1234",
+      display: "RxNorm Code"
+    },
+    Nubc: {
+      system: "NUBC",
+      code: "1234",
+      display: "NUBC Code"
+    }
   },
 
   Condition: {
@@ -46,37 +66,42 @@ export const TransitionTemplates = {
 }
 
 export const StateTemplates = {
-  Simple: {
-    type: "Simple",
-    name: "Simple_Template",
-  },
-
   Initial: {
     type: "Initial",
-    name: "Initial_Template",
   },
 
   Terminal: {
     type: "Terminal",
-    name: "Terminal_Template",
   },
 
-  Death: {
-    type: "Death",
-    name: "Death_Template",
+  Simple: {
+    type: "Simple",
+  },
+
+  Guard: {
+    type: "Guard",
+    allow: {...TypeTemplates.Condition.Age}
   },
 
   Delay: {
     type: "Delay",
-    name: "Delay_Template",
-    exact: {...TypeTemplates.Range.Exact}
+    exact: {...TypeTemplates.Range.ExactWithUnit}
   },
 
-  ConditionOnset: {
-    type: "ConditionOnset",
-    assign_to_attribute: "",
-    target_encounter: "",
-    codes: [{...TypeTemplates.Code}]
+  SetAttribute: {
+    type: "SetAttribute",
+    attribute: ""
+  },
+
+  Counter: {
+    type: "Counter",
+    attribute: "",
+    action: "increment"
+  },
+
+  CallSubmodule: {
+    type: "CallSubmodule",
+    submodule: ""
   },
 
   Encounter: {
@@ -86,26 +111,92 @@ export const StateTemplates = {
     codes: [{...TypeTemplates.Code}]
   },
 
+  EncounterEnd: {
+    type: "EncounterEnd"
+  },
+
+  ConditionOnset: {
+    type: "ConditionOnset",
+    assign_to_attribute: "",
+    target_encounter: "",
+    codes: [{...TypeTemplates.Code.Snomed}]
+  },
+
+  ConditionEnd: {
+    type: "ConditionEnd"
+  },
+
+  AllergyOnset: {
+    type: "AllergyOnset",
+    target_encounter: "",
+    codes: [{...TypeTemplates.Code.Snomed}]
+  },
+
+  AllergyEnd: {
+    type: "AllergyEnd"
+  },
+
   MedicationOrder: {
     type: "MedicationOrder",
-    codes: [{...TypeTemplates.Code}]
+    codes: [{...TypeTemplates.Code.RxNorm}]
+  },
+
+  MedicationEnd: {
+    type: "MedicationEnd"
+  },
+
+  CarePlanStart: {
+    type: "CarePlanStart",
+    codes: [{...TypeTemplates.Code.Snomed}]
+  },
+
+  CarePlanEnd: {
+    type: "CarePlanEnd"
   },
 
   Procedure: {
     type: "Procedure",
-    codes: [{...TypeTemplates.Code}]
+    codes: [{...TypeTemplates.Code.Snomed}]
+  },
+
+  VitalSign: {
+    type: "VitalSign",
+    vital_sign: "",
+    unit: "",
+    exact: {...TypeTemplates.Range.Exact}
   },
 
   Observation: {
     type: "Observation",
     category: "vital-signs",
     unit: "",
-    codes: [{...TypeTemplates.Code}]
+    codes: [{...TypeTemplates.Code.Loinc}],
+    exact: {...TypeTemplates.Range.Exact}
   },
 
-  Guard: {
-    type: "Guard",
-    allow: {...TypeTemplates.Condition.Age}
+  MultiObservation: {
+    type: "MultiObservation",
+    category: "vital-signs",
+    number_of_observations: 0,
+    codes: [{...TypeTemplates.Code.Loinc}]
+  },
+
+  DiagnosticReport: {
+    type: "DiagnosticReport",
+    number_of_observations: 0,
+    codes: [{...TypeTemplates.Code.Loinc}]
+  },
+
+  Symptom: {
+    type: "Symptom",
+    symptom: "",
+    cause: "",
+    exact: {...TypeTemplates.Range.Exact}
+  },
+
+  Death: {
+    type: "Death",
+    exact: {...TypeTemplates.Range.ExactWithUnit}
   }
 }
 


### PR DESCRIPTION
This PR implements the remaining state templates to enable adding any state type (resolves #73).

This PR also changes the order of the inputs in the code editors (resolves #55) and restricts the code systems of code editors to those that make sense (resolves #42).