### PR TITLE
Renaming states wont deselect the state.

### DIFF
--- a/src/reducers/editor.js
+++ b/src/reducers/editor.js
@@ -11,6 +11,9 @@ export default (state = initialState, action) => {
     case 'SELECT_NODE':
       return { ...state, selectedStateKey: action.data};
 
+    case 'RENAME_NODE':
+      return { ...state, selectedStateKey: action.data.newName.name};
+
     case 'ADD_NODE':
       let newState = {...state}
       newState.selectedStateKey = action.data.stateKey;

--- a/src/reducers/modules.js
+++ b/src/reducers/modules.js
@@ -58,8 +58,8 @@ export default (state = initialState, action) => {
 
     case 'RENAME_NODE':
       newState = {...state};
-      let oldModule = newState[action.data.targetModuleKey].states[action.data.targetNode.name];
-      newState[action.data.targetModuleKey].states[action.data.newName.name] = oldModule;
+      let oldState = newState[action.data.targetModuleKey].states[action.data.targetNode.name];
+      newState[action.data.targetModuleKey].states[action.data.newName.name] = {...oldState, name: action.data.newName.name};
       delete newState[action.data.targetModuleKey].states[action.data.targetNode.name];
       return newState;
     case 'EDIT_MODULE_NAME':


### PR DESCRIPTION
Updated so that renaming the state won't deselect it.  This implementation works when you press `enter` or click anywhere in the state editing area... but it doesn't work if you click in the module graph area because clicking on the module graph editor when a state is selected is interpreted as deselecting a state.  I'm unsure how big an issue this is.  Let me know what you think.

Fixes #66