### PR TITLE
Stop changes to new modules altering blank module template.

### DIFF
--- a/src/containers/Editor.js
+++ b/src/containers/Editor.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react'
 import { push } from 'react-router-redux'
 import { bindActionCreators } from 'redux'
 import { connect } from 'react-redux'
+import _ from 'lodash';
 
 import StateEditor from '../components/editor/State';
 import ModulePropertiesEditor from '../components/editor/ModuleProperties';
@@ -63,7 +64,7 @@ class Editor extends Component {
   }
 
   newModule = (takenKeys) => {
-    return (module = ModuleTemplates.Blank) => {
+    return (module = _.cloneDeep(ModuleTemplates.Blank)) => {
       let key = findAvailableKey(createSafeKeyFromName(module.name), takenKeys);
       this.props.newModule(key, module);
       this.props.push('#' + key)


### PR DESCRIPTION
When you create a new module, then make changes to it (name, remarks, states, state transitions), those changes would then show up when you create a new module.

This occurred because we were updating references to the 'master' copy of the blank template, and not making a clone of it before changing it.  I created a deepClone using lodash in a manner that is consistent with other parts of the codebase.

I'm a little concerned how easy this mistake was to make, and how it wasn't really immediately obvious that it was there.  Should we only expose a function for templates that does this cloning for you, instead of exposing the objects directly?

But this probably would fall under a low or medium priority at this point.

Closes #64