### PR TITLE
Disable structure button and add a tooltip on hover. Update tutorial.

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "react-router-dom": "^4.2.2",
     "react-router-redux": "^5.0.0-alpha.9",
     "react-scripts": "1.0.17",
+    "react-tooltip": "^3.4.0",
     "redux": "^3.7.2",
     "svg-pan-zoom": "^3.5.3",
     "uuid-js": "^0.7.5",

--- a/src/containers/Editor.css
+++ b/src/containers/Editor.css
@@ -19,3 +19,8 @@
 .nav-action-button {
   margin-left: 10px;
 }
+
+.__react_component_tooltip.react-tooltip-customized {
+  z-index: 10000 /* so it is over the navbar */
+
+}

--- a/src/containers/Editor.js
+++ b/src/containers/Editor.js
@@ -2,9 +2,9 @@ import React, { Component } from 'react'
 import { push } from 'react-router-redux'
 import { bindActionCreators } from 'redux'
 import { connect } from 'react-redux'
-import _ from 'lodash';
-import Joyride from 'react-joyride';
-
+import _ from 'lodash'
+import Joyride from 'react-joyride'
+import ReactTooltip from 'react-tooltip'
 
 import StateEditor from '../components/editor/State';
 import ModulePropertiesEditor from '../components/editor/ModuleProperties';
@@ -115,7 +115,8 @@ class Editor extends Component {
               <button className="btn btn-link nav-item nav-link" onClick={this.props.showLoadModule}>Load Module</button>
               <button className="btn btn-link nav-item nav-link" onClick={this.props.showDownload}>Download</button>
               <button className='btn btn-secondary nav-action-button' onClick={this.addNode(this.props.selectedModuleKey, Object.keys(this.props.module.states))}> Add State </button>
-              <button className='btn btn-secondary nav-action-button' onClick={() => this.props.addStructure(this.props.selectedModuleKey, 'CheckYearly')}> Add Structure </button>
+              {/*<button className='btn btn-secondary nav-action-button' onClick={() => this.props.addStructure(this.props.selectedModuleKey, 'CheckYearly')}> Add Structure </button> */}
+              <button className='btn btn-secondary nav-action-button disabled' data-tip='Structures are not yet implemented' onClick={() => null}> Add Structure </button>
               <button className='btn btn-secondary nav-action-button' onClick={this.startTutorial(BasicTutorial)}> Help </button>
             </div>
           </div>
@@ -159,6 +160,7 @@ class Editor extends Component {
             selectedState={this.props.moduleState}/>
 
         </div>
+
         <Joyride
           ref={c => (this.joyride = c)}
           showOverlay={true}
@@ -172,6 +174,11 @@ class Editor extends Component {
           allowClicksThruHole={false}
           keyboardNavigation={true}
         />
+
+        <ReactTooltip
+          className='react-tooltip-customized'
+          effect='solid'
+          />
 
       </div>
     )

--- a/src/containers/Editor.js
+++ b/src/containers/Editor.js
@@ -116,7 +116,7 @@ class Editor extends Component {
               <button className="btn btn-link nav-item nav-link" onClick={this.props.showDownload}>Download</button>
               <button className='btn btn-secondary nav-action-button' onClick={this.addNode(this.props.selectedModuleKey, Object.keys(this.props.module.states))}> Add State </button>
               {/*<button className='btn btn-secondary nav-action-button' onClick={() => this.props.addStructure(this.props.selectedModuleKey, 'CheckYearly')}> Add Structure </button> */}
-              <button className='btn btn-secondary nav-action-button disabled' data-tip='Structures are not yet implemented' onClick={() => null}> Add Structure </button>
+              <button className='btn btn-secondary nav-action-button disabled' data-tip='Structures are not yet available' onClick={() => null}> Add Structure </button>
               <button className='btn btn-secondary nav-action-button' onClick={this.startTutorial(BasicTutorial)}> Help </button>
             </div>
           </div>

--- a/src/templates/Tutorial.js
+++ b/src/templates/Tutorial.js
@@ -5,7 +5,7 @@ export const BasicTutorial = [
   {title: "Edit Node", selector: "#node_Initial", text: "To edit a node you can click on it in the graph"},
   {title: "Module Remarks", selector: ".ModuleProperties-remarks", text: "This is a place to put any remarks or citations for this module."},
   {title: "Adding a State", selector: ".navbar-nav :nth-child(4)", text: "This will add a new state to the module, it can then be edited like any other state."},
-  {title: "Adding a Structure", selector: ".navbar-nav :nth-child(5)", text: "We have a few commonly used structures, this will allow you to add them to your module."},
+  {title: "Adding a Structure", selector: ".navbar-nav :nth-child(5)", text: "We have a few commonly used structures, this will allow you to add them to your module. This feature is not yet available."},
 ]
 
 export const EditTutorial = [

--- a/yarn.lock
+++ b/yarn.lock
@@ -1406,6 +1406,10 @@ clap@^1.0.9:
   dependencies:
     chalk "^1.1.3"
 
+classnames@^2.2.5:
+  version "2.2.5"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.5.tgz#fb3801d453467649ef3603c7d61a02bd129bde6d"
+
 clean-css@4.1.x:
   version "4.1.9"
   resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-4.1.9.tgz#35cee8ae7687a49b98034f70de00c4edd3826301"
@@ -5466,6 +5470,13 @@ react-scripts@1.0.17:
     whatwg-fetch "2.0.3"
   optionalDependencies:
     fsevents "1.1.2"
+
+react-tooltip@^3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/react-tooltip/-/react-tooltip-3.4.0.tgz#037f38f797c3e6b1b58d2534ccc8c2c76af4f52d"
+  dependencies:
+    classnames "^2.2.5"
+    prop-types "^15.6.0"
 
 react@^16.1.0:
   version "16.1.0"


### PR DESCRIPTION
Closes #92

Instead of removing the button, I disabled it and added a tooltip.  We can reuse this tooltip component for context-aware help as well.

![screen shot 2018-02-26 at 9 24 37 am](https://user-images.githubusercontent.com/412901/36675443-f2a39e40-1ad6-11e8-85b7-425c2a59bcb7.png)
