### PR TITLE
Distributed transition edits

### DIFF
--- a/src/components/editor/DistributedTransition.js
+++ b/src/components/editor/DistributedTransition.js
@@ -5,7 +5,7 @@ import _ from 'lodash';
 
 
 import type { DistributedTransition as DistributedTransitionType } from '../../types/Transition';
-import { TransitionTemplates } from '../../templates/Templates';
+import { AttributeTemplates, TransitionTemplates } from '../../templates/Templates';
 import type { State } from '../../types/State';
 import './Transition.css';
 
@@ -36,9 +36,7 @@ class DistributedTransition extends Component<Props> {
               <RIESelect className='editable-text' propName='transition' value={{id:t.to, text:t.to}} change={this.props.onChange(`[${i}].transition`)} options={options} />
             </label>
             <br/>
-            <label> Weight:
-              <RIENumber className='editable-text' value={t.distribution} propName='distribution' editProps={{step: .01, min: 0, max: 1}} format={this.formatAsPercentage} validate={this.checkInRange} change={this.props.onChange(`[${i}].distribution`)} />
-            </label>
+            {this.renderDistribution(t.distribution, i)}
             <br/>
             <a className='editable-text delete-button' onClick={() => this.props.onChange(`[${i}]`)({val: {id: null}})}>remove</a>
           </div>
@@ -50,12 +48,34 @@ class DistributedTransition extends Component<Props> {
     );
   }
 
+  renderDistribution(distribution: mixed, index: number) {
+    if(typeof distribution === 'object') {
+      return (
+        <label>
+          Attribute: <RIEInput className='editable-text' value={distribution.attribute} propName='attribute' change={this.props.onChange(`[${index}].distribution.attribute`)} />
+          <br />
+          Weight: <RIENumber className='editable-text' value={distribution.default} propName='default' editProps={{step: .01, min: 0, max: 1}} format={this.formatAsPercentage} validate={this.checkInRange} change={this.props.onChange(`[${index}].distribution.default`)} />
+          <br />
+          <a className='editable-text' onClick={() => this.props.onChange(`[${index}].distribution`)({val: {id: _.cloneDeep(AttributeTemplates.UnnamedDistribution)}})}>Change to Unnamed Distribution</a>
+        </label>
+      );
+    } else {
+      return (
+        <label> Weight:
+          <RIENumber className='editable-text' value={distribution} propName='distribution' editProps={{step: .01, min: 0, max: 1}} format={this.formatAsPercentage} validate={this.checkInRange} change={this.props.onChange(`[${index}].distribution`)} />
+          <br />
+          <a className='editable-text' onClick={() => this.props.onChange(`[${index}].distribution`)({val: {id: _.cloneDeep(AttributeTemplates.NamedDistribution)}})}>Change to Named Distribution</a>
+        </label>
+      );
+    }
+  }
+
   renderWarning() {
     if(!this.props.transition) {
       return null;
     }
     // TODO remove Number calls when it can be ensured the values are numbers
-    let warn = (this.props.transition.transition.reduce((acc, val) => Number(acc) + Number(val.distribution), 0) !== 1);
+    let warn = (this.props.transition.transition.reduce((acc, val) => Number(acc) + Number(typeof val.distribution === 'object' ? val.distribution.default : val.distribution), 0) !== 1);
     if (warn) {
       return (
         <label className='warning'>Weights do not add up to 100%.</label>

--- a/src/components/editor/DistributedTransition.js
+++ b/src/components/editor/DistributedTransition.js
@@ -29,7 +29,6 @@ class DistributedTransition extends Component<Props> {
 
     return (
       <label>
-
         Distributed Transition:
         {currentValue.map((t, i) => {
           return <div key={i} className="transition-option">
@@ -38,16 +37,38 @@ class DistributedTransition extends Component<Props> {
             </label>
             <br/>
             <label> Weight:
-            <RIENumber className='editable-text' value={t.distribution} propName='distribution' change={this.props.onChange(`[${i}].distribution`)} />
-
+              <RIENumber className='editable-text' value={t.distribution} propName='distribution' editProps={{step: .01, min: 0, max: 1}} format={this.formatAsPercentage} validate={this.checkInRange} change={this.props.onChange(`[${i}].distribution`)} />
             </label>
             <br/>
             <a className='editable-text delete-button' onClick={() => this.props.onChange(`[${i}]`)({val: {id: null}})}>remove</a>
           </div>
         })}
         <a className='editable-text add-button' onClick={() => this.props.onChange(`[${currentValue.length}]`)({val: {id: _.cloneDeep(TransitionTemplates.Distributed[0])}})}>+</a>
+        <br/>
+        {this.renderWarning()}
       </label>
     );
+  }
+
+  renderWarning() {
+    if(!this.props.transition) {
+      return null;
+    }
+    // TODO remove Number calls when it can be ensured the values are numbers
+    let warn = (this.props.transition.transition.reduce((acc, val) => Number(acc) + Number(val.distribution), 0) !== 1);
+    if (warn) {
+      return (
+        <label className='warning'>Weights do not add up to 100%.</label>
+      );
+    }
+  }
+
+  formatAsPercentage(num: number) {
+    return (num * 100) + "%";
+  }
+
+  checkInRange(num: number) {
+    return ((num >= 0) && (num <= 1));
   }
 }
 

--- a/src/components/editor/State.css
+++ b/src/components/editor/State.css
@@ -71,3 +71,7 @@ span.editable-text > :empty:after {
   color: inherit;
   cursor:pointer;
 }
+
+.warning {
+  color: #ff3300;
+}

--- a/src/templates/Templates.js
+++ b/src/templates/Templates.js
@@ -243,14 +243,20 @@ export const AttributeTemplates = {
     codes: [{...TypeTemplates.Code.Loinc}],
     operator: "==",
     value: 1
+  },
+  UnnamedDistribution: 1.0,
+  NamedDistribution: {
+    attribute: "attribute",
+    default: 1.0
   }
+
 }
 
 
 export const TransitionTemplates = {
   Direct: 'Initial',
   Conditional: [{transition: 'Initial', condition: {...TypeTemplates.Condition.Age}}],
-  Distributed: [{transition: 'Initial', distribution: 0.0}],
+  Distributed: [{transition: 'Initial', distribution: 1.0}],
   Complex: [{condition: {...TypeTemplates.Condition.Age}, distributions: [], to: 'Initial'}]
 }
 

--- a/src/types/Transition.js
+++ b/src/types/Transition.js
@@ -10,7 +10,10 @@ export type DistributedTransition = {
   type: 'Distributed',
   transition: [
     {
-      distribution: number,
+      distribution: {
+        attribute: string,
+        default: number
+      } | number,
       to: string
     }
   ]

--- a/src/types/Transition.js
+++ b/src/types/Transition.js
@@ -4,16 +4,16 @@ import type { Conditional } from './Conditional';
 export type DirectTransition = {
   to: string,
   type: 'Direct'
-}
+};
 
 export type DistributedTransition = {
   type: 'Distributed',
   transition: [
-      {
-        distibution: number,
-        to: string
-      }
-    ]
+    {
+      distribution: number,
+      to: string
+    }
+  ]
 };
 
 export type ConditionalTransition = {
@@ -24,7 +24,7 @@ export type ConditionalTransition = {
       to: string
     }
   ]
-}
+};
 
 export type ComplexTransition = {
   type: 'Complex',
@@ -33,6 +33,6 @@ export type ComplexTransition = {
     distributions ?: DistributedTransition,
     transition ?: DirectTransition
   }]
-}
+};
 
 export type Transition = DirectTransition | DistributedTransition | ConditionalTransition | ComplexTransition;


### PR DESCRIPTION
This PR makes many changes to distributed transitions.

-Changes display of transition weights to percentages (closes #51)
-Changes step size of transition weights to 0.01 or 1% (closes #50)
-Enforces bounds of 0% and 100% for transition weights (closes #49)
-Implements naming of distributed transitions (closes #102)