### PR TITLE
Fix bug on remove state

### DIFF
--- a/src/reducers/modules.js
+++ b/src/reducers/modules.js
@@ -27,9 +27,9 @@ export default (state = initialState, action) => {
         _.unset(newState, path);
         // debugger
         let parent = [...action.data.path].splice(0, action.data.path.length -1).join(".");
-        let newVal = _.get(newState, parent).filter(x => x);
+        let newVal = _.get(newState, parent);
         if(Array.isArray(newVal)) {
-          _.set(newState, parent, newVal);
+          _.set(newState, parent, newVal.filter(x => x));
         }
       }
 


### PR DESCRIPTION
A simple bug in the code caused the console to throw an error on removing a state. This PR addresses fixes that bug (closes #104).