### PR TITLE
Fixes issue where too many transitions are highlighted on node select.

### DIFF
--- a/src/utils/graphviz.js
+++ b/src/utils/graphviz.js
@@ -107,11 +107,9 @@ const transitionsAsDOT = (module: Module, selectedState: State) => {
         console.log(`NO SUCH NODE TO TRANSITION TO: ${state.direct_transition}`);
       }
     } else if(state.distributed_transition !== undefined){
-      if(selectedState && state.distributed_transition === selectedState.name){
-        className = ''
-      }
       let out_transitions = ''
       state.distributed_transition.forEach( t => {
+        let transitionClassName = className
         let distLabel = ''
         if(typeof t.distribution === 'object'){
           distLabel = `p(${t.distribution.attribute})`
@@ -125,9 +123,9 @@ const transitionsAsDOT = (module: Module, selectedState: State) => {
         }
         if(module.states[t.transition]){
           if(selectedState && t.transition === selectedState.name){
-            className = '';
+            transitionClassName = '';
           }
-          out_transitions += `  "${name}" -> "${module.states[t.transition].name}" [label = "${distLabel}", class = "transition ${className}"];\n`
+          out_transitions += `  "${name}" -> "${module.states[t.transition].name}" [label = "${distLabel}", class = "transition ${transitionClassName}"];\n`
         } else {
           console.log(`NO SUCH NODE TO TRANSITION TO: ${t.transition}`);
         }
@@ -136,12 +134,13 @@ const transitionsAsDOT = (module: Module, selectedState: State) => {
     } else if (state.conditional_transition !== undefined){
       let out_transitions = ''
       state.conditional_transition.forEach( (t, i ) => {
+        let transitionClassName = className
         let cnd = t.condition !== undefined ? logicDetails(t.condition) : 'else';
         if(module.states[t.transition]){
           if(selectedState && t.transition === selectedState.name){
-            className = ''
+            transitionClassName = ''
           }
-          out_transitions += `  "${name}" -> "${module.states[t.transition].name}" [label = "${i+1}. ${cnd}", class = "transition ${className}"];\n`
+          out_transitions += `  "${name}" -> "${module.states[t.transition].name}" [label = "${i+1}. ${cnd}", class = "transition ${transitionClassName}"];\n`
         } else {
           console.log(`NO SUCH NODE TO TRANSITION TO: ${t.transition}\n`);
         }
@@ -193,13 +192,14 @@ const transitionsAsDOT = (module: Module, selectedState: State) => {
 
       let out_transitions = ''
       Object.keys(transitions).forEach( trans => {
+        let transitionClassName = className
         if(nodeHighlighted[trans] === 'standard'){
-          className = ''
+          transitionClassName = ''
         }
         if(nodeHighlighted[trans] === 'highlighted'){
-          className='transition-highlighted'
+          transitionClassName='transition-highlighted'
         }
-        out_transitions += `${trans} [label = "${transitions[trans].join(',\\n')}", class = "transition ${className}"]\n`
+        out_transitions += `${trans} [label = "${transitions[trans].join(',\\n')}", class = "transition ${transitionClassName}"]\n`
       })
 
       return out_transitions;

--- a/src/utils/graphviz.js
+++ b/src/utils/graphviz.js
@@ -98,7 +98,7 @@ const transitionsAsDOT = (module: Module, selectedState: State) => {
     }
 
     if(state.direct_transition !== undefined){
-      if(selectedState && state.direct_transition === selectedState.name){
+      if(selectedState && state.direct_transition === selectedState.name && selectedState.name !== name){
         className='';
       }
       if(module.states[state.direct_transition]){
@@ -122,7 +122,7 @@ const transitionsAsDOT = (module: Module, selectedState: State) => {
           distLabel = `${pct}%`
         }
         if(module.states[t.transition]){
-          if(selectedState && t.transition === selectedState.name){
+          if(selectedState && t.transition === selectedState.name && selectedState.name !== name){
             transitionClassName = '';
           }
           out_transitions += `  "${name}" -> "${module.states[t.transition].name}" [label = "${distLabel}", class = "transition ${transitionClassName}"];\n`
@@ -195,8 +195,7 @@ const transitionsAsDOT = (module: Module, selectedState: State) => {
         let transitionClassName = className
         if(nodeHighlighted[trans] === 'standard'){
           transitionClassName = ''
-        }
-        if(nodeHighlighted[trans] === 'highlighted'){
+        } else if(nodeHighlighted[trans] === 'highlighted'){
           transitionClassName='transition-highlighted'
         }
         out_transitions += `${trans} [label = "${transitions[trans].join(',\\n')}", class = "transition ${transitionClassName}"]\n`


### PR DESCRIPTION
Please manually inspect that I got all all transition types (click on nodes that are connected to distributed, conditional, simple, etc).  I think I got everything but I'd appreciate a second look because the logic here is complex.

Before:

![screen shot 2018-03-06 at 9 17 23 am](https://user-images.githubusercontent.com/412901/37037169-b64d6102-211f-11e8-96bd-03f65b920622.png)

After:

![screen shot 2018-03-06 at 9 16 18 am](https://user-images.githubusercontent.com/412901/37037189-c000381e-211f-11e8-97d3-4ff1da985b49.png)

Also fixed transition highlights looping to themselves:

![screen shot 2018-03-06 at 10 09 43 am](https://user-images.githubusercontent.com/412901/37039896-9499c904-2126-11e8-91cd-ad11b7e4c078.png)


Fixes #27, #53 